### PR TITLE
feat: Add StyledComponents decorator for Styled object

### DIFF
--- a/packages/ui/src/utils/styles/styled-component.js
+++ b/packages/ui/src/utils/styles/styled-component.js
@@ -1,4 +1,4 @@
-export const StyledComponent = ({ displayName }) => Component => {
+export const StyledComponent = (displayName) => Component => {
   Component.displayName = displayName;
   Component.attrs = [
     props => ({

--- a/packages/ui/src/utils/styles/styled-component.js
+++ b/packages/ui/src/utils/styles/styled-component.js
@@ -1,10 +1,16 @@
-export const StyledComponent = (displayName) => Component => {
-  Component.displayName = displayName;
-  Component.attrs = [
-    props => ({
-      className: `${props.classNames?.[displayName] || ''} ${props?.className || ''}`.trim(),
-    }),
-  ];
-
-  return Component;
-};
+export const StyledComponents = object =>
+  Object.keys(object).reduce(
+    (injectedObject, componentKey) =>
+      Object.assign(injectedObject, {
+        [componentKey]: {
+          ...object[componentKey],
+          displayName: componentKey,
+          attrs: [
+            props => ({
+              className: `${props.classNames?.[displayName] || ''} ${props?.className || ''}`.trim(),
+            }),
+          ],
+        },
+      }),
+    {}
+  );

--- a/packages/ui/src/utils/styles/styled-component.js
+++ b/packages/ui/src/utils/styles/styled-component.js
@@ -1,16 +1,15 @@
-export const StyledComponents = object =>
-  Object.keys(object).reduce(
-    (injectedObject, componentKey) =>
-      Object.assign(injectedObject, {
-        [componentKey]: {
-          ...object[componentKey],
-          displayName: componentKey,
-          attrs: [
-            props => ({
-              className: `${props.classNames?.[displayName] || ''} ${props?.className || ''}`.trim(),
-            }),
-          ],
-        },
-      }),
-    {}
-  );
+export const StyledComponents = object => {
+  return Object.keys(object).reduce((injectedObject, componentKey) => {
+    return Object.assign(injectedObject, {
+      [componentKey]: {
+        ...object[componentKey],
+        displayName: componentKey,
+        attrs: [
+          props => ({
+            className: `${props.classNames?.[componentKey] || ''} ${props?.className || ''}`.trim(),
+          }),
+        ],
+      },
+    });
+  }, {});
+};

--- a/packages/ui/src/utils/styles/styled-component.js
+++ b/packages/ui/src/utils/styles/styled-component.js
@@ -1,0 +1,10 @@
+export const StyledComponent = ({ displayName }) => Component => {
+  Component.displayName = displayName;
+  Component.attrs = [
+    props => ({
+      className: `${props.classNames?.[displayName] || ''} ${props?.className || ''}`.trim(),
+    }),
+  ];
+
+  return Component;
+};


### PR DESCRIPTION
`StyledComponent` decorator is added before every styled component declaration:
```
const Button = StyledComponent('Button')(styled.button)
```

It allows injecting static `displayName`, optional root `className` and access own `classNames` from respective object, that must be passed through props.