### PR TITLE
chore: Remove unnecessary `prerelease` script call

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest",
     "ci": "npm-run-all -s build test",
     "prerelease": "yarn build && node scripts/create-meta-files.js",
-    "release": "yarn prerelease && lerna publish --yes --conventional-commits --create-release github --contents lib",
+    "release": "lerna publish --yes --conventional-commits --create-release github --contents lib",
     "deploy": "storybook-to-ghpages --ci",
     "cd": "npm-run-all -p deploy release"
   },


### PR DESCRIPTION
`prerelease` is still being called before `release`.